### PR TITLE
Prevent crash when xcrun fails

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,7 +21,12 @@ export async function activate(context: ExtensionContext): Promise<void> {
 
   let commandPath = config.commandPath
   if (!commandPath) {
-    commandPath = (await workspace.runCommand('xcrun --toolchain swift --find sourcekit-lsp')).trim()
+    try {
+      commandPath = (await workspace.runCommand('xcrun --toolchain swift --find sourcekit-lsp')).trim()
+    } catch {
+      workspace.showMessage("Cannot find sourcekit-lsp. Install a Swift toolchain or set `sourcekit.commandPath` in your coc-config.")
+      return
+    }
   }
 
   const serverOptions: ServerOptions = {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -19,9 +19,13 @@ export async function activate(context: ExtensionContext): Promise<void> {
     return
   }
 
- const commandPath = (await workspace.runCommand('xcrun --toolchain swift --find sourcekit-lsp')).trim()
+  let commandPath = config.commandPath
+  if (!commandPath) {
+    commandPath = (await workspace.runCommand('xcrun --toolchain swift --find sourcekit-lsp')).trim()
+  }
+
   const serverOptions: ServerOptions = {
-    command: config.commandPath || commandPath,
+    command: commandPath,
     transport: TransportKind.stdio
   }
 


### PR DESCRIPTION
When xcrun failed we weren't taking the commandPath from
`config.commandPath` making it impossible to specify where sourcekit-lsp
is when xcrun can't find it.

This fixes the issue by only running `xcrun` when `config.commandPath` is empty. This also shows an error message when `xcrun` fails to run explaining that either a toolchain needs to be installed or `config.commandPath` be set.

Fixes #1