### PR TITLE
Remove toolchain requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ See [sourcekit-lsp].
 |Key|Description|Default|
 |----|------------|-----|
 |`sourcekit.enable`|Enable sourcekit extension|true|
-|`sourcekit.commandPath`|Path to sourcekit-lsp binary|Output of `xcrun --toolchain swift --find sourcekit-lsp`|
+|`sourcekit.commandPath`|Path to sourcekit-lsp binary|Output of `xcrun --find sourcekit-lsp`|
 |`sourcekit.trace.server`|Trace the communication between coc and the sourcekit language server|
 |`sourcekit.iOSsdkPath`| The path to the desired iOS SDK | Output of `xcrun --sdk iphonesimulator --show-sdk-path`) |
 |`sourcekit.targetArch`| The name of the target (e.g x86_64-apple-ios13.2-simulator) to generate code |

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -24,9 +24,9 @@ export async function activate(context: ExtensionContext): Promise<void> {
   let commandPath = config.commandPath
   if (!commandPath) {
     try {
-      commandPath = (await workspace.runCommand('xcrun --toolchain swift --find sourcekit-lsp')).trim()
+      commandPath = (await workspace.runCommand('xcrun --find sourcekit-lsp')).trim()
     } catch {
-      workspace.showMessage("Cannot find sourcekit-lsp. Install a Swift toolchain or set `sourcekit.commandPath` in your coc-config.")
+      workspace.showMessage("Cannot find sourcekit-lsp. Install Xcode 11.4+ or set `sourcekit.commandPath` in your coc-config.")
       return
     }
   }


### PR DESCRIPTION
Since Xcode 11.4 sourcekit-lsp has been bundled, so this argument or
recommendation to install a toolchain is no longer required