### PR TITLE
Update options

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,10 @@ See [sourcekit-lsp].
 |`sourcekit.enable`|Enable sourcekit extension|true|
 |`sourcekit.commandPath`|Path to sourcekit-lsp binary|Output of `xcrun --toolchain swift --find sourcekit-lsp`|
 |`sourcekit.trace.server`|Trace the communication between coc and the sourcekit language server|
-|`sourcekit.iOSsdkPath`| The path to the desired iOS SDK | Output of `xcrun --sdk iphonesimulator --show-sdk-path`) |
+|`sourcekit.sdkPath`|The path to the desired SDK|Nothing|
+|`sourcekit.sdk`|The name to the desired SDK to be fetched|Nothing|
 |`sourcekit.targetArch`| The name of the target (e.g x86_64-apple-ios13.2-simulator) to generate code |
+|`sourcekit.args`|Extra arguments to pass to the lsp|[]|
 
 ## Development
 

--- a/package.json
+++ b/package.json
@@ -53,15 +53,25 @@
           ],
           "description": "Trace the communication between coc and the sourcekit language server"
         },
-        "sourcekit.iOSsdkPath": {
+        "sourcekit.sdkPath": {
             "type": "string",
             "default": "",
-            "description": "The path to the desired iOS SDK"
+            "description": "The path to the desired SDK"
+        },
+        "sourcekit.sdk": {
+            "type": "string",
+            "default": "",
+            "description": "The name of the SDK to use"
         },
         "sourcekit.targetArch": {
             "type": "string",
             "default": "",
             "description": "The name of the target to generate code"
+        },
+        "sourcekit.args": {
+            "type": "array",
+            "default": [],
+            "description": "Extra arguments to pass to the lsp"
         }
       }
     }


### PR DESCRIPTION
This changes the available options to be more generic for use with non
iOS platforms. This replaces the previous `iOSsdkPath` with a more
generic `sdkPath` to make it clear this doesn't have to be iOS specific.
It also adds `sdk` which allows a SDK name so you don't have to hardcode
the specific path. If you don't pass either of these the default macOS
SDK is used. This also exposes arbitrary arguments for users to pass
other args.