### PR TITLE
Find sourcekit-lsp with which

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ See [sourcekit-lsp].
 |Key|Description|Default|
 |----|------------|-----|
 |`sourcekit.enable`|Enable sourcekit extension|true|
-|`sourcekit.commandPath`|Path to sourcekit-lsp binary|Output of `xcrun --find sourcekit-lsp`|
+|`sourcekit.commandPath`|Path to sourcekit-lsp binary|Output of `which sourcekit-lsp`|
 |`sourcekit.trace.server`|Trace the communication between coc and the sourcekit language server|
 |`sourcekit.sdkPath`|The path to the desired SDK|Nothing|
 |`sourcekit.sdk`|The name to the desired SDK to be fetched|Nothing|

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -26,9 +26,9 @@ export async function activate(context: ExtensionContext): Promise<void> {
   let commandPath = config.commandPath
   if (!commandPath) {
     try {
-      commandPath = (await workspace.runCommand('xcrun --find sourcekit-lsp')).trim()
+      commandPath = (await workspace.runCommand('which sourcekit-lsp')).trim()
     } catch {
-      workspace.showMessage("Cannot find sourcekit-lsp. Install Xcode 11.4+ or set `sourcekit.commandPath` in your coc-config.")
+      workspace.showMessage("Cannot find sourcekit-lsp. Install Xcode 11.4+, swift, or set `sourcekit.commandPath` in your coc-config.")
       return
     }
   }


### PR DESCRIPTION
`which` is present on macOS out of the box, and is present on most other platforms too.

Tested on macOS Big Sur and ArchLinux.

Fixes #15